### PR TITLE
Remove deprecation warnings 

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,8 @@ define(function() {
     
     var CommandManager = brackets.getModule("command/CommandManager"),
         Commands = brackets.getModule("command/Commands"),
-        DocumentManager = brackets.getModule("document/DocumentManager");
+        DocumentManager = brackets.getModule("document/DocumentManager"),
+        EditorManager = brackets.getModule("editor/EditorManager");
     
     /**
      * Saves a document.
@@ -21,12 +22,11 @@ define(function() {
         }
     }
     
-    $(DocumentManager).on('currentDocumentChange', function(e, currDoc, prevDoc) {
+    EditorManager.on('activeEditorChange', function(e, currDoc, prevDoc) {
         save(prevDoc);
     });
     
-    var secondBlur = false;
-    $(window).on('blur', function(e) {
+    $(window).on('blur', function() {
         save(DocumentManager.getCurrentDocument());
     });
 });

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
     "name": "zeid.autosave-on-view-change",
     "title": "Autosave on View Change",
     "description": "Autosave current file when changing files or on window blur.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "Joshua Zeid <jrzeid23+github@gmail.com> (https://github.com/marcantony)",
-	"homepage": "https://github.com/marcantony/brackets-autosave-on-view-change",
+    "homepage": "https://github.com/marcantony/brackets-autosave-on-view-change",
     "license": "MIT",
     "engines": {
-        "brackets": ">=0.40.0"
+        "brackets": ">=1.1.0"
     }
 }


### PR DESCRIPTION
Fixes #3. :smiley: 

I did test this, and the extension still works as it should. This change raises the minimum Brackets version to v1.1.